### PR TITLE
Changes to resolve issue #5 and #8

### DIFF
--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
@@ -30,17 +30,12 @@ public class PasswordKeyUtil {
     public static EncryptionKey loadKeyFrom(XMLConfiguration xml, EncryptionKey defaultKey) {
         String xmlKey = xml.getString("passwordKey", null);
         String xmlSource = xml.getString("passwordKeySource", null);
-        String xmlAlgorithm = xml.getString("passwordKeyAlgorithm", null);
         if (StringUtils.isNotBlank(xmlKey)) {
             EncryptionKey.Source source = null;
-            EncryptionKey.Algorithm algorithm = null;
             if (StringUtils.isNotBlank(xmlSource)) {
                 source = EncryptionKey.Source.valueOf(xmlSource.toUpperCase());
             }
-            if (StringUtils.isNotBlank(xmlAlgorithm)) {
-                algorithm = EncryptionKey.Algorithm.valueOf(xmlAlgorithm.toUpperCase());
-            }
-            return new EncryptionKey(xmlKey, source, algorithm);
+            return new EncryptionKey(xmlKey, source);
         }
         return defaultKey;
     }
@@ -61,10 +56,6 @@ public class PasswordKeyUtil {
             writer.writeElementString("passwordKey", passwordKey.getValue());
             if (passwordKey.getSource() != null) {
                 writer.writeElementString("passwordKeySource",
-                        passwordKey.getSource().name().toLowerCase());
-            }
-            if (passwordKey.getSource() != null) {
-                writer.writeElementString("passwordKeyAlgorithm",
                         passwordKey.getSource().name().toLowerCase());
             }
         }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
@@ -30,12 +30,13 @@ public class PasswordKeyUtil {
     public static EncryptionKey loadKeyFrom(XMLConfiguration xml, EncryptionKey defaultKey) {
         String xmlKey = xml.getString("passwordKey", null);
         String xmlSource = xml.getString("passwordKeySource", null);
+        Integer size = xml.getInteger("passwordKeySize", EncryptionKey.DEFAULT_KEY_SIZE);
         if (StringUtils.isNotBlank(xmlKey)) {
             EncryptionKey.Source source = null;
             if (StringUtils.isNotBlank(xmlSource)) {
                 source = EncryptionKey.Source.valueOf(xmlSource.toUpperCase());
             }
-            return new EncryptionKey(xmlKey, source);
+            return new EncryptionKey(xmlKey, source, size);
         }
         return defaultKey;
     }
@@ -54,11 +55,11 @@ public class PasswordKeyUtil {
     public static void saveKeyTo(EnhancedXMLStreamWriter writer, EncryptionKey passwordKey) throws XMLStreamException {
         if (passwordKey != null) {
             writer.writeElementString("passwordKey", passwordKey.getValue());
+            writer.writeElementInteger("passwordKeySize", passwordKey.getSize());
             if (passwordKey.getSource() != null) {
                 writer.writeElementString("passwordKeySource",
                         passwordKey.getSource().name().toLowerCase());
             }
         }
     }
-
 }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
@@ -1,0 +1,64 @@
+package com.norconex.commons.lang.config;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.lang3.StringUtils;
+
+import com.norconex.commons.lang.encrypt.EncryptionKey;
+import com.norconex.commons.lang.encrypt.EncryptionUtil;
+import com.norconex.commons.lang.xml.EnhancedXMLStreamWriter;
+
+/**
+ * <p>Allows many classes implementing {@link IXMLConfigurable} to load and store an {@link EncryptionKey} in a standard manner through delegation.</p>
+ *
+ * @author davisda4
+ * @since 1.9.1
+ * @see EncryptionUtil
+ *
+ */
+public class PasswordKeyUtil {
+    public static EncryptionKey loadKeyFrom(Reader in, EncryptionKey defaultKey) {
+        XMLConfiguration xml = XMLConfigurationUtil.newXMLConfiguration(in);
+        return loadKeyFrom(xml, defaultKey);
+    }
+
+    public static EncryptionKey loadKeyFrom(XMLConfiguration xml, EncryptionKey defaultKey) {
+        String xmlKey = xml.getString("passwordKey", null);
+        String xmlSource = xml.getString("passwordKeySource", null);
+        if (StringUtils.isNotBlank(xmlKey)) {
+            EncryptionKey.Source source = null;
+            if (StringUtils.isNotBlank(xmlSource)) {
+                source = EncryptionKey.Source.valueOf(xmlSource.toUpperCase());
+            }
+            return new EncryptionKey(xmlKey, source);
+        }
+        return defaultKey;
+    }
+
+
+    public static void saveKeyTo(Writer out, EncryptionKey passwordKey) throws IOException {
+        try {
+            EnhancedXMLStreamWriter writer = new EnhancedXMLStreamWriter(out);
+            saveKeyTo(writer, passwordKey);
+        } catch (XMLStreamException e) {
+            throw new IOException("Cannot save as XML.", e);
+
+        }
+    }
+
+    public static void saveKeyTo(EnhancedXMLStreamWriter writer, EncryptionKey passwordKey) throws XMLStreamException {
+        if (passwordKey != null) {
+            writer.writeElementString("passwordKey", passwordKey.getValue());
+            if (passwordKey.getSource() != null) {
+                writer.writeElementString("passwordKeySource",
+                        passwordKey.getSource().name().toLowerCase());
+            }
+        }
+    }
+
+}

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/config/PasswordKeyUtil.java
@@ -30,12 +30,17 @@ public class PasswordKeyUtil {
     public static EncryptionKey loadKeyFrom(XMLConfiguration xml, EncryptionKey defaultKey) {
         String xmlKey = xml.getString("passwordKey", null);
         String xmlSource = xml.getString("passwordKeySource", null);
+        String xmlAlgorithm = xml.getString("passwordKeyAlgorithm", null);
         if (StringUtils.isNotBlank(xmlKey)) {
             EncryptionKey.Source source = null;
+            EncryptionKey.Algorithm algorithm = null;
             if (StringUtils.isNotBlank(xmlSource)) {
                 source = EncryptionKey.Source.valueOf(xmlSource.toUpperCase());
             }
-            return new EncryptionKey(xmlKey, source);
+            if (StringUtils.isNotBlank(xmlAlgorithm)) {
+                algorithm = EncryptionKey.Algorithm.valueOf(xmlAlgorithm.toUpperCase());
+            }
+            return new EncryptionKey(xmlKey, source, algorithm);
         }
         return defaultKey;
     }
@@ -56,6 +61,10 @@ public class PasswordKeyUtil {
             writer.writeElementString("passwordKey", passwordKey.getValue());
             if (passwordKey.getSource() != null) {
                 writer.writeElementString("passwordKeySource",
+                        passwordKey.getSource().name().toLowerCase());
+            }
+            if (passwordKey.getSource() != null) {
+                writer.writeElementString("passwordKeyAlgorithm",
                         passwordKey.getSource().name().toLowerCase());
             }
         }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionKey.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionKey.java
@@ -22,10 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
- * Pointer to the an encryption key, or the encryption key itself. An
- * encryption key can be seen as equivalent to a secret key,
+ * Pointer to the an encryption key, or the encryption key itself. An 
+ * encryption key can be seen as equivalent to a secret key, 
  * passphrase or password.
- *
  * @author Pascal Essiembre
  * @since 1.9.0
  * @see EncryptionUtil
@@ -34,62 +33,38 @@ public class EncryptionKey implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public enum Source {
+    public enum Source { 
         /** Value is the actual key. */
-        KEY,
+        KEY, 
         /** Value is the path to a file containing the key. */
-        FILE,
+        FILE, 
         /** Value is the name of an environment variable containing the key. */
-        ENVIRONMENT,
+        ENVIRONMENT, 
         /** Value is the name of a JVM system property containing the key. */
         PROPERTY
     }
 
-    public enum Algorithm {
-        /** Algorithm is determined automatically, using a magic number in the stronger key */
-        AUTO,
-        /** Algorithm is the newer, stronger algorithm */
-        STRONG,
-        /** Algorithm is the legacy algorithm */
-        LEGACY
-    }
-
     private final String value;
     private final Source source;
-    private final Algorithm algorithm;
-
+    
     /**
-     * Creates a new reference to an encryption key. The reference can either
+     * Creates a new reference to an encryption key. The reference can either 
      * be the key itself, or a pointer to a file or environment variable
      * containing the key (as defined by the supplied value type).
-     *
-     * @param value the encryption key
-     * @param source the type of value
-     * @param algorithm the algorithm to use
-     */
-    public EncryptionKey(String value, Source source, Algorithm algorithm) {
-        super();
-        this.value = value;
-        this.source = source;
-        this.algorithm = algorithm;
-    }
-    /**
-     * Creates a new reference to an encryption key. The reference can either
-     * be the key itself, or a pointer to a file or environment variable
-     * containing the key (as defined by the supplied value type).
-     *
      * @param value the encryption key
      * @param source the type of value
      */
     public EncryptionKey(String value, Source source) {
-        this(value, source, Algorithm.AUTO);
+        super();
+        this.value = value;
+        this.source = source;
     }
     /**
-     * Creates a new encryption key where the value is the actual key, and the algorithm is determined automatically.
+     * Creates a new encryption key where the value is the actual key.
      * @param value the encryption key
      */
     public EncryptionKey(String value) {
-        this(value, Source.KEY, Algorithm.AUTO);
+        this(value, Source.KEY);
     }
     public String getValue() {
         return value;
@@ -97,15 +72,13 @@ public class EncryptionKey implements Serializable {
     public Source getSource() {
         return source;
     }
-    public Algorithm getAlgorithm() {
-        return algorithm;
-    }
+
     /**
-     * Locate the key according to its value type and return it.  This
-     * method will always resolve the value each type it is invoked and
+     * Locate the key according to its value type and return it.  This 
+     * method will always resolve the value each type it is invoked and 
      * never caches the key, unless the key value specified at construction
      * time is the actual key.
-     * @return encryption key or <code>null</code> if the key does not exist
+     * @return encryption key or <code>null</code> if the key does not exist 
      * for the specified type
      */
     public String resolve() {
@@ -128,12 +101,12 @@ public class EncryptionKey implements Serializable {
             return null;
         }
     }
-
+    
     private String fromEnv() {
         //TODO allow a flag to optionally throw an exception when null?
         return System.getenv(value);
     }
-
+    
     private String fromProperty() {
         //TODO allow a flag to optionally throw an exception when null?
         return System.getProperty(value);
@@ -155,7 +128,7 @@ public class EncryptionKey implements Serializable {
                     "Could not read key file.", e);
         }
     }
-
+    
     //Do not use Apache Commons Lang below to avoid any dependency
     //when used on command-line with EncryptionUtil.
     @Override
@@ -163,7 +136,6 @@ public class EncryptionKey implements Serializable {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((source == null) ? 0 : source.hashCode());
-        result = prime * result + ((algorithm == null) ? 0 : algorithm.hashCode());
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
     }
@@ -182,9 +154,6 @@ public class EncryptionKey implements Serializable {
         if (source != other.source) {
             return false;
         }
-        if (algorithm != other.algorithm) {
-            return false;
-        }
         if (value == null) {
             if (other.value != null) {
                 return false;
@@ -196,6 +165,6 @@ public class EncryptionKey implements Serializable {
     }
     @Override
     public String toString() {
-        return "EncryptionKey [value=" + value + ", source=" + source + ", algorithm=" + algorithm + "]";
-    }
+        return "EncryptionKey [value=" + value + ", source=" + source + "]";
+    }    
 }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionKey.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionKey.java
@@ -22,9 +22,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
- * Pointer to the an encryption key, or the encryption key itself. An 
- * encryption key can be seen as equivalent to a secret key, 
+ * Pointer to the an encryption key, or the encryption key itself. An
+ * encryption key can be seen as equivalent to a secret key,
  * passphrase or password.
+ *
  * @author Pascal Essiembre
  * @since 1.9.0
  * @see EncryptionUtil
@@ -33,38 +34,62 @@ public class EncryptionKey implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public enum Source { 
+    public enum Source {
         /** Value is the actual key. */
-        KEY, 
+        KEY,
         /** Value is the path to a file containing the key. */
-        FILE, 
+        FILE,
         /** Value is the name of an environment variable containing the key. */
-        ENVIRONMENT, 
+        ENVIRONMENT,
         /** Value is the name of a JVM system property containing the key. */
         PROPERTY
     }
 
+    public enum Algorithm {
+        /** Algorithm is determined automatically, using a magic number in the stronger key */
+        AUTO,
+        /** Algorithm is the newer, stronger algorithm */
+        STRONG,
+        /** Algorithm is the legacy algorithm */
+        LEGACY
+    }
+
     private final String value;
     private final Source source;
-    
+    private final Algorithm algorithm;
+
     /**
-     * Creates a new reference to an encryption key. The reference can either 
+     * Creates a new reference to an encryption key. The reference can either
      * be the key itself, or a pointer to a file or environment variable
      * containing the key (as defined by the supplied value type).
+     *
+     * @param value the encryption key
+     * @param source the type of value
+     * @param algorithm the algorithm to use
+     */
+    public EncryptionKey(String value, Source source, Algorithm algorithm) {
+        super();
+        this.value = value;
+        this.source = source;
+        this.algorithm = algorithm;
+    }
+    /**
+     * Creates a new reference to an encryption key. The reference can either
+     * be the key itself, or a pointer to a file or environment variable
+     * containing the key (as defined by the supplied value type).
+     *
      * @param value the encryption key
      * @param source the type of value
      */
     public EncryptionKey(String value, Source source) {
-        super();
-        this.value = value;
-        this.source = source;
+        this(value, source, Algorithm.AUTO);
     }
     /**
-     * Creates a new encryption key where the value is the actual key.
+     * Creates a new encryption key where the value is the actual key, and the algorithm is determined automatically.
      * @param value the encryption key
      */
     public EncryptionKey(String value) {
-        this(value, Source.KEY);
+        this(value, Source.KEY, Algorithm.AUTO);
     }
     public String getValue() {
         return value;
@@ -72,13 +97,15 @@ public class EncryptionKey implements Serializable {
     public Source getSource() {
         return source;
     }
-
+    public Algorithm getAlgorithm() {
+        return algorithm;
+    }
     /**
-     * Locate the key according to its value type and return it.  This 
-     * method will always resolve the value each type it is invoked and 
+     * Locate the key according to its value type and return it.  This
+     * method will always resolve the value each type it is invoked and
      * never caches the key, unless the key value specified at construction
      * time is the actual key.
-     * @return encryption key or <code>null</code> if the key does not exist 
+     * @return encryption key or <code>null</code> if the key does not exist
      * for the specified type
      */
     public String resolve() {
@@ -101,12 +128,12 @@ public class EncryptionKey implements Serializable {
             return null;
         }
     }
-    
+
     private String fromEnv() {
         //TODO allow a flag to optionally throw an exception when null?
         return System.getenv(value);
     }
-    
+
     private String fromProperty() {
         //TODO allow a flag to optionally throw an exception when null?
         return System.getProperty(value);
@@ -128,7 +155,7 @@ public class EncryptionKey implements Serializable {
                     "Could not read key file.", e);
         }
     }
-    
+
     //Do not use Apache Commons Lang below to avoid any dependency
     //when used on command-line with EncryptionUtil.
     @Override
@@ -136,6 +163,7 @@ public class EncryptionKey implements Serializable {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((source == null) ? 0 : source.hashCode());
+        result = prime * result + ((algorithm == null) ? 0 : algorithm.hashCode());
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         return result;
     }
@@ -154,6 +182,9 @@ public class EncryptionKey implements Serializable {
         if (source != other.source) {
             return false;
         }
+        if (algorithm != other.algorithm) {
+            return false;
+        }
         if (value == null) {
             if (other.value != null) {
                 return false;
@@ -165,6 +196,6 @@ public class EncryptionKey implements Serializable {
     }
     @Override
     public String toString() {
-        return "EncryptionKey [value=" + value + ", source=" + source + "]";
-    }    
+        return "EncryptionKey [value=" + value + ", source=" + source + ", algorithm=" + algorithm + "]";
+    }
 }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
@@ -15,25 +15,40 @@
 package com.norconex.commons.lang.encrypt;
 
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
+import java.util.Arrays;
 
+import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 
 import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
+import com.norconex.commons.lang.io.ByteArrayOutputStream;
 
 /**
- * <p>Simplified encryption and decryption methods using the 
- * "PBEWithMD5AndDES" algorithm with a supplied encryption key (which you 
+ * <p>Simplified encryption and decryption methods using the
+ * "PBEWithMD5AndDES" algorithm with a supplied encryption key (which you
  * can also think of as a passphrase, or password).
  * The "salt" and iteration count used by this class are hard-coded. To have
- * more control and ensure a more secure approach, you should rely on another 
+ * more control and ensure a more secure approach, you should rely on another
  * implementation or create your own.
  * </p>
  * <p>
@@ -44,7 +59,7 @@ import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
  * java -cp norconex-commons-lang-[version].jar com.norconex.commons.lang.encrypt.EncryptionUtil
  * </pre>
  * <p>
- * For example, to use a encryption key store in a file to encrypt some text, 
+ * For example, to use a encryption key store in a file to encrypt some text,
  * add the following arguments to the above command:
  * </p>
  * <pre>
@@ -54,12 +69,12 @@ import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
  * As of 1.13.0, you can also use the <code>encrypt.[sh|bat]</code> and
  * <code>decrypt.[sh|bat]</code> files distributed with this library.
  * </p>
- * 
+ *
  * @author Pascal Essiembre
  * @since 1.9.0
  */
 public class EncryptionUtil {
-    
+
     private EncryptionUtil() {
         super();
     }
@@ -72,7 +87,7 @@ public class EncryptionUtil {
         String typeArg = args[1];
         String keyArg = args[2];
         String textArg = args[3];
-        
+
         Source type = null;
         if ("-k".equalsIgnoreCase(typeArg)) {
             type = Source.KEY;
@@ -86,7 +101,7 @@ public class EncryptionUtil {
             System.err.println("Unsupported type of key: " + type);
             printUsage();
         }
-        
+
         EncryptionKey key = new EncryptionKey(keyArg, type);
         if ("encrypt".equalsIgnoreCase(cmdArg)) {
             System.out.println(encrypt(textArg, key));
@@ -116,19 +131,26 @@ public class EncryptionUtil {
         out.println("  text     text to encrypt or decrypt");
         System.exit(-1);
     }
-    
+
     /**
      * <p>Encrypts the given text with the encryption key supplied. If the
      * encryption key is <code>null</code> or resolves to blank key,
      * the text to encrypt will be returned unmodified.</p>
      * @param textToEncrypt text to be encrypted
-     * @param encryptionKey encryption key which must resolve to the same 
+     * @param encryptionKey encryption key which must resolve to the same
      *        value to encrypt and decrypt the supplied text.
-     * @return encrypted text or <code>null</code> if 
+     * @return encrypted text or <code>null</code> if
      * <code>textToEncrypt</code> is <code>null</code>.
+     * @throws NoSuchAlgorithmException
+     * @throws UnsupportedEncodingException
      */
     public static String encrypt(
             String textToEncrypt, EncryptionKey encryptionKey) {
+        // 8-byte Salt
+        byte[] salt = {
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
+            (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
+        };
         if (textToEncrypt == null) {
             return null;
         }
@@ -139,51 +161,57 @@ public class EncryptionUtil {
         if (key == null) {
             return textToEncrypt;
         }
-        
-        // 8-byte Salt
-        byte[] salt = {
-            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9, 
-            (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
-        };
+
         // Iteration count
-        int iterationCount = 19;
+        int iterationCount = 1000;
+        int keySize = 128;
         Cipher ecipher;
 
         try {
             // Create the key
             KeySpec keySpec = new PBEKeySpec(
-                    key.trim().toCharArray(), salt, iterationCount);
-            SecretKey secretKey = SecretKeyFactory.getInstance(
-                "PBEWithMD5AndDES").generateSecret(keySpec);
-            ecipher = Cipher.getInstance(secretKey.getAlgorithm());
+                    key.trim().toCharArray(), salt, iterationCount, keySize);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            SecretKey secretKeyTemp = factory.generateSecret(keySpec);
+            SecretKey secretKey = new SecretKeySpec(secretKeyTemp.getEncoded(), "AES");
 
-            // Prepare the parameter to the ciphers
-            AlgorithmParameterSpec paramSpec = 
-                    new PBEParameterSpec(salt, iterationCount);
+            ecipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            ecipher.init(Cipher.ENCRYPT_MODE, secretKey);
 
-            // Create the ciphers
-            ecipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec);
-            
+            AlgorithmParameters params = ecipher.getParameters();
+
+            byte[] iv = params.getParameterSpec(IvParameterSpec.class).getIV();
             byte[] utf8 = textToEncrypt.trim().getBytes(StandardCharsets.UTF_8);
-            byte[] enc = ecipher.doFinal(utf8);
-            
-            return DatatypeConverter.printBase64Binary(enc);
+            byte[] cipherBytes = ecipher.doFinal(utf8);
+
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            bos.write(iv);
+            bos.write(cipherBytes);
+            bos.close();
+            byte[] cryptMessage = bos.toByteArray();
+
+            return DatatypeConverter.printBase64Binary(cryptMessage);
         } catch (Exception e) {
             throw new EncryptionException("Encryption failed.", e);
         }
     }
- 
+
     /**
      * <p>Decrypts the given encrypted text with the encryption key supplied.
      * </p>
      * @param encryptedText text to be decrypted
-     * @param encryptionKey encryption key which must resolve to the same 
+     * @param encryptionKey encryption key which must resolve to the same
      *        value to encrypt and decrypt the supplied text.
-     * @return decrypted text or <code>null</code> if one of 
+     * @return decrypted text or <code>null</code> if one of
      * <code>encryptedText</code> or <code>key</code> is <code>null</code>.
-     */   
+     */
     public static String decrypt(
             String encryptedText, EncryptionKey encryptionKey) {
+        // 8-byte Salt
+        byte[] salt = {
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
+            (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
+        };
         if (encryptedText == null) {
             return null;
         }
@@ -193,38 +221,70 @@ public class EncryptionUtil {
         String key = encryptionKey.resolve();
         if (key == null) {
             return encryptedText;
-        }        
-        
+        }
+
+        // Iteration count
+        int iterationCount = 1000;
+        int keySize = 128;
+        Cipher dcipher;
+
+        try {
+            // Separate the encrypted data into the salt and the encrypted message
+            byte[] cryptMessage = DatatypeConverter.parseBase64Binary(encryptedText.trim());
+            byte[] iv = Arrays.copyOf(cryptMessage, 16);
+            byte[] cryptBytes = Arrays.copyOfRange(cryptMessage, 16, cryptMessage.length);
+
+            // Create the key
+            KeySpec keySpec = new PBEKeySpec(
+                    key.trim().toCharArray(), salt, iterationCount, keySize);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            SecretKey secretKeyTemp = factory.generateSecret(keySpec);
+            SecretKey secretKey = new SecretKeySpec(secretKeyTemp.getEncoded(), "AES");
+
+            IvParameterSpec ivParamSpec = new IvParameterSpec(iv);
+
+            dcipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            dcipher.init(Cipher.DECRYPT_MODE, secretKey, ivParamSpec);
+
+            byte[] utf8 = dcipher.doFinal(cryptBytes);
+            return new String(utf8, StandardCharsets.UTF_8);
+        } catch (Exception original) {
+            try {
+                return decryptLegacy(encryptedText, key);
+            } catch (GeneralSecurityException subsequent) {
+                throw new EncryptionException("Decryption failed.", original);
+            }
+        }
+    }
+
+    private static String decryptLegacy(String encryptedText, String key) throws GeneralSecurityException {
         // 8-byte Salt
         byte[] salt = {
-            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9, 
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
             (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
         };
         // Iteration count
         int iterationCount = 19;
         Cipher dcipher;
 
-        try {
-            // Create the key
-            KeySpec keySpec = new PBEKeySpec(
-                    key.trim().toCharArray(), salt, iterationCount);
-            SecretKey secretKey = SecretKeyFactory.getInstance(
-                "PBEWithMD5AndDES").generateSecret(keySpec);
-            dcipher = Cipher.getInstance(secretKey.getAlgorithm());
+        // Create the key
+        KeySpec keySpec = new PBEKeySpec(
+                key.trim().toCharArray(), salt, iterationCount);
+        SecretKey secretKey = SecretKeyFactory.getInstance(
+            "PBEWithMD5AndDES").generateSecret(keySpec);
+        dcipher = Cipher.getInstance(secretKey.getAlgorithm());
 
-            // Prepare the parameter to the ciphers
-            AlgorithmParameterSpec paramSpec = 
-                    new PBEParameterSpec(salt, iterationCount);
+        // Prepare the parameter to the ciphers
+        AlgorithmParameterSpec paramSpec =
+                new PBEParameterSpec(salt, iterationCount);
 
-            // Create the ciphers
-            dcipher.init(Cipher.DECRYPT_MODE, secretKey, paramSpec);
-            
-            byte[] dec = 
-                    DatatypeConverter.parseBase64Binary(encryptedText.trim());
-            byte[] utf8 = dcipher.doFinal(dec);
-            return new String(utf8, StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            throw new EncryptionException("Decryption failed.", e);
-        }
+        // Create the ciphers
+        dcipher.init(Cipher.DECRYPT_MODE, secretKey, paramSpec);
+
+        byte[] dec =
+                DatatypeConverter.parseBase64Binary(encryptedText.trim());
+        byte[] utf8 = dcipher.doFinal(dec);
+        return new String(utf8, StandardCharsets.UTF_8);
     }
+
 }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
@@ -29,11 +29,11 @@ import javax.xml.bind.DatatypeConverter;
 import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
 
 /**
- * <p>Simplified encryption and decryption methods using the 
- * "PBEWithMD5AndDES" algorithm with a supplied encryption key (which you 
+ * <p>Simplified encryption and decryption methods using the
+ * "PBEWithMD5AndDES" algorithm with a supplied encryption key (which you
  * can also think of as a passphrase, or password).
  * The "salt" and iteration count used by this class are hard-coded. To have
- * more control and ensure a more secure approach, you should rely on another 
+ * more control and ensure a more secure approach, you should rely on another
  * implementation or create your own.
  * </p>
  * <p>
@@ -44,7 +44,7 @@ import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
  * java -cp norconex-commons-lang-[version].jar com.norconex.commons.lang.encrypt.EncryptionUtil
  * </pre>
  * <p>
- * For example, to use a encryption key store in a file to encrypt some text, 
+ * For example, to use a encryption key store in a file to encrypt some text,
  * add the following arguments to the above command:
  * </p>
  * <pre>
@@ -54,12 +54,12 @@ import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
  * As of 1.13.0, you can also use the <code>encrypt.[sh|bat]</code> and
  * <code>decrypt.[sh|bat]</code> files distributed with this library.
  * </p>
- * 
+ *
  * @author Pascal Essiembre
  * @since 1.9.0
  */
 public class EncryptionUtil {
-    
+
     private EncryptionUtil() {
         super();
     }
@@ -72,7 +72,7 @@ public class EncryptionUtil {
         String typeArg = args[1];
         String keyArg = args[2];
         String textArg = args[3];
-        
+
         Source type = null;
         if ("-k".equalsIgnoreCase(typeArg)) {
             type = Source.KEY;
@@ -86,7 +86,7 @@ public class EncryptionUtil {
             System.err.println("Unsupported type of key: " + type);
             printUsage();
         }
-        
+
         EncryptionKey key = new EncryptionKey(keyArg, type);
         if ("encrypt".equalsIgnoreCase(cmdArg)) {
             System.out.println(encrypt(textArg, key));
@@ -116,33 +116,11 @@ public class EncryptionUtil {
         out.println("  text     text to encrypt or decrypt");
         System.exit(-1);
     }
-    
-    /**
-     * <p>Encrypts the given text with the encryption key supplied. If the
-     * encryption key is <code>null</code> or resolves to blank key,
-     * the text to encrypt will be returned unmodified.</p>
-     * @param textToEncrypt text to be encrypted
-     * @param encryptionKey encryption key which must resolve to the same 
-     *        value to encrypt and decrypt the supplied text.
-     * @return encrypted text or <code>null</code> if 
-     * <code>textToEncrypt</code> is <code>null</code>.
-     */
-    public static String encrypt(
-            String textToEncrypt, EncryptionKey encryptionKey) {
-        if (textToEncrypt == null) {
-            return null;
-        }
-        if (encryptionKey == null) {
-            return textToEncrypt;
-        }
-        String key = encryptionKey.resolve();
-        if (key == null) {
-            return textToEncrypt;
-        }
-        
+
+    private static String encryptLegacy(String textToEncrypt, String key) {
         // 8-byte Salt
         byte[] salt = {
-            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9, 
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
             (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
         };
         // Iteration count
@@ -158,46 +136,29 @@ public class EncryptionUtil {
             ecipher = Cipher.getInstance(secretKey.getAlgorithm());
 
             // Prepare the parameter to the ciphers
-            AlgorithmParameterSpec paramSpec = 
+            AlgorithmParameterSpec paramSpec =
                     new PBEParameterSpec(salt, iterationCount);
 
             // Create the ciphers
             ecipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec);
-            
+
             byte[] utf8 = textToEncrypt.trim().getBytes(StandardCharsets.UTF_8);
             byte[] enc = ecipher.doFinal(utf8);
-            
+
             return DatatypeConverter.printBase64Binary(enc);
         } catch (Exception e) {
             throw new EncryptionException("Encryption failed.", e);
         }
     }
- 
-    /**
-     * <p>Decrypts the given encrypted text with the encryption key supplied.
-     * </p>
-     * @param encryptedText text to be decrypted
-     * @param encryptionKey encryption key which must resolve to the same 
-     *        value to encrypt and decrypt the supplied text.
-     * @return decrypted text or <code>null</code> if one of 
-     * <code>encryptedText</code> or <code>key</code> is <code>null</code>.
-     */   
-    public static String decrypt(
-            String encryptedText, EncryptionKey encryptionKey) {
-        if (encryptedText == null) {
-            return null;
-        }
-        if (encryptionKey == null) {
-            return encryptedText;
-        }
-        String key = encryptionKey.resolve();
-        if (key == null) {
-            return encryptedText;
-        }        
-        
+
+    private static String encryptStrong(String textToEncrypt, String key) {
+        return encryptLegacy(textToEncrypt, key);
+    }
+
+    private static String decryptLegacy(String encryptedText, String key) {
         // 8-byte Salt
         byte[] salt = {
-            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9, 
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
             (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
         };
         // Iteration count
@@ -213,18 +174,91 @@ public class EncryptionUtil {
             dcipher = Cipher.getInstance(secretKey.getAlgorithm());
 
             // Prepare the parameter to the ciphers
-            AlgorithmParameterSpec paramSpec = 
+            AlgorithmParameterSpec paramSpec =
                     new PBEParameterSpec(salt, iterationCount);
 
             // Create the ciphers
             dcipher.init(Cipher.DECRYPT_MODE, secretKey, paramSpec);
-            
-            byte[] dec = 
+
+            byte[] dec =
                     DatatypeConverter.parseBase64Binary(encryptedText.trim());
             byte[] utf8 = dcipher.doFinal(dec);
             return new String(utf8, StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new EncryptionException("Decryption failed.", e);
+        }
+    }
+
+    private static String decryptStrong(String encryptedText, String key) {
+        return decryptLegacy(encryptedText, key);
+    }
+
+    private static String decryptAutomatic(String encryptedText, String key) {
+        return decryptLegacy(encryptedText, key);
+
+    }
+
+    /**
+     * <p>Encrypts the given text with the encryption key supplied. If the
+     * encryption key is <code>null</code> or resolves to blank key,
+     * the text to encrypt will be returned unmodified.</p>
+     * @param textToEncrypt text to be encrypted
+     * @param encryptionKey encryption key which must resolve to the same
+     *        value to encrypt and decrypt the supplied text.
+     * @return encrypted text or <code>null</code> if
+     * <code>textToEncrypt</code> is <code>null</code>.
+     */
+    public static String encrypt(String textToEncrypt, EncryptionKey encryptionKey) {
+        if (textToEncrypt == null) {
+            return null;
+        }
+        if (encryptionKey == null) {
+            return textToEncrypt;
+        }
+        String key = encryptionKey.resolve();
+        if (key == null) {
+            return textToEncrypt;
+        }
+        switch (encryptionKey.getAlgorithm()) {
+            case LEGACY:
+                return encryptLegacy(textToEncrypt, key);
+            case STRONG:
+            case AUTO:
+            default:
+                return encryptStrong(textToEncrypt, key);
+        }
+    }
+
+    /**
+     * <p>Decrypts the given encrypted text with the encryption key supplied.
+     * </p>
+     * @param encryptedText text to be decrypted
+     * @param encryptionKey encryption key which must resolve to the same
+     *        value to encrypt and decrypt the supplied text.
+     * @return decrypted text or <code>null</code> if one of
+     * <code>encryptedText</code> or <code>key</code> is <code>null</code>.
+     */
+    public static String decrypt(
+            String encryptedText, EncryptionKey encryptionKey) {
+        if (encryptedText == null) {
+            return null;
+        }
+        if (encryptionKey == null) {
+            return encryptedText;
+        }
+        String key = encryptionKey.resolve();
+        if (key == null) {
+            return encryptedText;
+        }
+
+        switch (encryptionKey.getAlgorithm()) {
+            case LEGACY:
+                return decryptLegacy(encryptedText, key);
+            case STRONG:
+                return decryptStrong(encryptedText, key);
+            case AUTO:
+            default:
+                return decryptAutomatic(encryptedText, key);
         }
     }
 }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
@@ -164,7 +164,7 @@ public class EncryptionUtil {
 
         // Iteration count
         int iterationCount = 1000;
-        int keySize = 128;
+        int keySize = encryptionKey.getSize();
         Cipher ecipher;
 
         try {
@@ -225,7 +225,7 @@ public class EncryptionUtil {
 
         // Iteration count
         int iterationCount = 1000;
-        int keySize = 128;
+        int keySize = encryptionKey.getSize();
         Cipher dcipher;
 
         try {

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
@@ -171,7 +171,8 @@ public class EncryptionUtil {
             // Create the key
             KeySpec keySpec = new PBEKeySpec(
                     key.trim().toCharArray(), salt, iterationCount, keySize);
-            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+
             SecretKey secretKeyTemp = factory.generateSecret(keySpec);
             SecretKey secretKey = new SecretKeySpec(secretKeyTemp.getEncoded(), "AES");
 
@@ -237,7 +238,7 @@ public class EncryptionUtil {
             // Create the key
             KeySpec keySpec = new PBEKeySpec(
                     key.trim().toCharArray(), salt, iterationCount, keySize);
-            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
             SecretKey secretKeyTemp = factory.generateSecret(keySpec);
             SecretKey secretKey = new SecretKeySpec(secretKeyTemp.getEncoded(), "AES");
 

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/encrypt/EncryptionUtil.java
@@ -29,11 +29,11 @@ import javax.xml.bind.DatatypeConverter;
 import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
 
 /**
- * <p>Simplified encryption and decryption methods using the
- * "PBEWithMD5AndDES" algorithm with a supplied encryption key (which you
+ * <p>Simplified encryption and decryption methods using the 
+ * "PBEWithMD5AndDES" algorithm with a supplied encryption key (which you 
  * can also think of as a passphrase, or password).
  * The "salt" and iteration count used by this class are hard-coded. To have
- * more control and ensure a more secure approach, you should rely on another
+ * more control and ensure a more secure approach, you should rely on another 
  * implementation or create your own.
  * </p>
  * <p>
@@ -44,7 +44,7 @@ import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
  * java -cp norconex-commons-lang-[version].jar com.norconex.commons.lang.encrypt.EncryptionUtil
  * </pre>
  * <p>
- * For example, to use a encryption key store in a file to encrypt some text,
+ * For example, to use a encryption key store in a file to encrypt some text, 
  * add the following arguments to the above command:
  * </p>
  * <pre>
@@ -54,12 +54,12 @@ import com.norconex.commons.lang.encrypt.EncryptionKey.Source;
  * As of 1.13.0, you can also use the <code>encrypt.[sh|bat]</code> and
  * <code>decrypt.[sh|bat]</code> files distributed with this library.
  * </p>
- *
+ * 
  * @author Pascal Essiembre
  * @since 1.9.0
  */
 public class EncryptionUtil {
-
+    
     private EncryptionUtil() {
         super();
     }
@@ -72,7 +72,7 @@ public class EncryptionUtil {
         String typeArg = args[1];
         String keyArg = args[2];
         String textArg = args[3];
-
+        
         Source type = null;
         if ("-k".equalsIgnoreCase(typeArg)) {
             type = Source.KEY;
@@ -86,7 +86,7 @@ public class EncryptionUtil {
             System.err.println("Unsupported type of key: " + type);
             printUsage();
         }
-
+        
         EncryptionKey key = new EncryptionKey(keyArg, type);
         if ("encrypt".equalsIgnoreCase(cmdArg)) {
             System.out.println(encrypt(textArg, key));
@@ -116,11 +116,33 @@ public class EncryptionUtil {
         out.println("  text     text to encrypt or decrypt");
         System.exit(-1);
     }
-
-    private static String encryptLegacy(String textToEncrypt, String key) {
+    
+    /**
+     * <p>Encrypts the given text with the encryption key supplied. If the
+     * encryption key is <code>null</code> or resolves to blank key,
+     * the text to encrypt will be returned unmodified.</p>
+     * @param textToEncrypt text to be encrypted
+     * @param encryptionKey encryption key which must resolve to the same 
+     *        value to encrypt and decrypt the supplied text.
+     * @return encrypted text or <code>null</code> if 
+     * <code>textToEncrypt</code> is <code>null</code>.
+     */
+    public static String encrypt(
+            String textToEncrypt, EncryptionKey encryptionKey) {
+        if (textToEncrypt == null) {
+            return null;
+        }
+        if (encryptionKey == null) {
+            return textToEncrypt;
+        }
+        String key = encryptionKey.resolve();
+        if (key == null) {
+            return textToEncrypt;
+        }
+        
         // 8-byte Salt
         byte[] salt = {
-            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9, 
             (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
         };
         // Iteration count
@@ -136,29 +158,46 @@ public class EncryptionUtil {
             ecipher = Cipher.getInstance(secretKey.getAlgorithm());
 
             // Prepare the parameter to the ciphers
-            AlgorithmParameterSpec paramSpec =
+            AlgorithmParameterSpec paramSpec = 
                     new PBEParameterSpec(salt, iterationCount);
 
             // Create the ciphers
             ecipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec);
-
+            
             byte[] utf8 = textToEncrypt.trim().getBytes(StandardCharsets.UTF_8);
             byte[] enc = ecipher.doFinal(utf8);
-
+            
             return DatatypeConverter.printBase64Binary(enc);
         } catch (Exception e) {
             throw new EncryptionException("Encryption failed.", e);
         }
     }
-
-    private static String encryptStrong(String textToEncrypt, String key) {
-        return encryptLegacy(textToEncrypt, key);
-    }
-
-    private static String decryptLegacy(String encryptedText, String key) {
+ 
+    /**
+     * <p>Decrypts the given encrypted text with the encryption key supplied.
+     * </p>
+     * @param encryptedText text to be decrypted
+     * @param encryptionKey encryption key which must resolve to the same 
+     *        value to encrypt and decrypt the supplied text.
+     * @return decrypted text or <code>null</code> if one of 
+     * <code>encryptedText</code> or <code>key</code> is <code>null</code>.
+     */   
+    public static String decrypt(
+            String encryptedText, EncryptionKey encryptionKey) {
+        if (encryptedText == null) {
+            return null;
+        }
+        if (encryptionKey == null) {
+            return encryptedText;
+        }
+        String key = encryptionKey.resolve();
+        if (key == null) {
+            return encryptedText;
+        }        
+        
         // 8-byte Salt
         byte[] salt = {
-            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9,
+            (byte)0xE3, (byte)0x03, (byte)0x9B, (byte)0xA9, 
             (byte)0xC8, (byte)0x16, (byte)0x35, (byte)0x56
         };
         // Iteration count
@@ -174,91 +213,18 @@ public class EncryptionUtil {
             dcipher = Cipher.getInstance(secretKey.getAlgorithm());
 
             // Prepare the parameter to the ciphers
-            AlgorithmParameterSpec paramSpec =
+            AlgorithmParameterSpec paramSpec = 
                     new PBEParameterSpec(salt, iterationCount);
 
             // Create the ciphers
             dcipher.init(Cipher.DECRYPT_MODE, secretKey, paramSpec);
-
-            byte[] dec =
+            
+            byte[] dec = 
                     DatatypeConverter.parseBase64Binary(encryptedText.trim());
             byte[] utf8 = dcipher.doFinal(dec);
             return new String(utf8, StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new EncryptionException("Decryption failed.", e);
-        }
-    }
-
-    private static String decryptStrong(String encryptedText, String key) {
-        return decryptLegacy(encryptedText, key);
-    }
-
-    private static String decryptAutomatic(String encryptedText, String key) {
-        return decryptLegacy(encryptedText, key);
-
-    }
-
-    /**
-     * <p>Encrypts the given text with the encryption key supplied. If the
-     * encryption key is <code>null</code> or resolves to blank key,
-     * the text to encrypt will be returned unmodified.</p>
-     * @param textToEncrypt text to be encrypted
-     * @param encryptionKey encryption key which must resolve to the same
-     *        value to encrypt and decrypt the supplied text.
-     * @return encrypted text or <code>null</code> if
-     * <code>textToEncrypt</code> is <code>null</code>.
-     */
-    public static String encrypt(String textToEncrypt, EncryptionKey encryptionKey) {
-        if (textToEncrypt == null) {
-            return null;
-        }
-        if (encryptionKey == null) {
-            return textToEncrypt;
-        }
-        String key = encryptionKey.resolve();
-        if (key == null) {
-            return textToEncrypt;
-        }
-        switch (encryptionKey.getAlgorithm()) {
-            case LEGACY:
-                return encryptLegacy(textToEncrypt, key);
-            case STRONG:
-            case AUTO:
-            default:
-                return encryptStrong(textToEncrypt, key);
-        }
-    }
-
-    /**
-     * <p>Decrypts the given encrypted text with the encryption key supplied.
-     * </p>
-     * @param encryptedText text to be decrypted
-     * @param encryptionKey encryption key which must resolve to the same
-     *        value to encrypt and decrypt the supplied text.
-     * @return decrypted text or <code>null</code> if one of
-     * <code>encryptedText</code> or <code>key</code> is <code>null</code>.
-     */
-    public static String decrypt(
-            String encryptedText, EncryptionKey encryptionKey) {
-        if (encryptedText == null) {
-            return null;
-        }
-        if (encryptionKey == null) {
-            return encryptedText;
-        }
-        String key = encryptionKey.resolve();
-        if (key == null) {
-            return encryptedText;
-        }
-
-        switch (encryptionKey.getAlgorithm()) {
-            case LEGACY:
-                return decryptLegacy(encryptedText, key);
-            case STRONG:
-                return decryptStrong(encryptedText, key);
-            case AUTO:
-            default:
-                return decryptAutomatic(encryptedText, key);
         }
     }
 }

--- a/norconex-commons-lang/src/main/java/com/norconex/commons/lang/net/ProxySettings.java
+++ b/norconex-commons-lang/src/main/java/com/norconex/commons/lang/net/ProxySettings.java
@@ -36,6 +36,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 
 import com.norconex.commons.lang.config.IXMLConfigurable;
+import com.norconex.commons.lang.config.PasswordKeyUtil;
 import com.norconex.commons.lang.config.XMLConfigurationUtil;
 import com.norconex.commons.lang.encrypt.EncryptionKey;
 import com.norconex.commons.lang.encrypt.EncryptionUtil;
@@ -43,7 +44,7 @@ import com.norconex.commons.lang.xml.EnhancedXMLStreamWriter;
 
 /**
  * Convenience class for implementation requiring proxy settings.
- * 
+ *
  * @author Pascal Essiembre
  * @since 1.14.0
  */
@@ -58,7 +59,7 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
     private String proxyPassword;
     private EncryptionKey proxyPasswordKey;
     private String proxyRealm;
-    
+
     public ProxySettings() {
         super();
     }
@@ -120,7 +121,7 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
     public boolean isSet() {
         return StringUtils.isNotBlank(proxyHost);
     }
-    
+
     public void copyFrom(ProxySettings another) {
         proxyHost = another.proxyHost;
         proxyPort = another.proxyPort;
@@ -130,7 +131,7 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
         proxyPasswordKey = another.proxyPasswordKey;
         proxyRealm = another.proxyRealm;
     }
-    
+
     /**
      * Creates an Apache {@link HttpHost}.
      * @return HttpHost or <code>null</code> if proxy is not set.
@@ -149,7 +150,7 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
     }
     public Credentials createCredentials() {
         if (isSet() && StringUtils.isNotBlank(proxyUsername)) {
-            String password = 
+            String password =
                     EncryptionUtil.decrypt(proxyPassword, proxyPasswordKey);
             return new UsernamePasswordCredentials(proxyUsername, password);
         }
@@ -170,7 +171,7 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
     protected String getXmlTag() {
         return "proxy";
     }
-    
+
     /**
      * Loads from a {@link #getXmlTag()} tag.
      * @param in XML reader
@@ -189,8 +190,7 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
         proxyScheme = xml.getString("proxyScheme", proxyScheme);
         proxyUsername = xml.getString("proxyUsername", proxyUsername);
         proxyPassword = xml.getString("proxyPassword", proxyPassword);
-        proxyPasswordKey = 
-                loadXMLPasswordKey(xml, "proxyPasswordKey", proxyPasswordKey);
+        proxyPasswordKey = PasswordKeyUtil.loadKeyFrom(xml, proxyPasswordKey);
         proxyRealm = xml.getString("proxyRealm", proxyRealm);
     }
     /**
@@ -227,36 +227,10 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
         writer.writeElementString("proxyScheme", proxyScheme);
         writer.writeElementString("proxyUsername", proxyUsername);
         writer.writeElementString("proxyPassword", proxyPassword);
-        saveXMLPasswordKey(writer, "proxyPasswordKey", proxyPasswordKey);
+        PasswordKeyUtil.saveKeyTo(writer, proxyPasswordKey);
         writer.writeElementString("proxyRealm", proxyRealm);
     }
 
-    private void saveXMLPasswordKey(EnhancedXMLStreamWriter writer, 
-            String field, EncryptionKey key) throws XMLStreamException {
-        if (key == null) {
-            return;
-        }
-        writer.writeElementString(field, key.getValue());
-        if (key.getSource() != null) {
-            writer.writeElementString(
-                    field + "Source", key.getSource().name().toLowerCase());
-        }
-    }
-    
-    private EncryptionKey loadXMLPasswordKey(
-            XMLConfiguration xml, String field, EncryptionKey defaultKey) {
-        String xmlKey = xml.getString(field, null);
-        String xmlSource = xml.getString(field + "Source", null);
-        if (StringUtils.isBlank(xmlKey)) {
-            return defaultKey;
-        }
-        EncryptionKey.Source source = null;
-        if (StringUtils.isNotBlank(xmlSource)) {
-            source = EncryptionKey.Source.valueOf(xmlSource.toUpperCase());
-        }
-        return new EncryptionKey(xmlKey, source);
-    }
-    
     @Override
     public boolean equals(final Object other) {
         if (!(other instanceof ProxySettings)) {
@@ -298,5 +272,5 @@ public class ProxySettings implements IXMLConfigurable, Serializable {
                 .append("proxyPasswordKey", proxyPasswordKey)
                 .append("proxyRealm", proxyRealm)
                 .toString();
-    }    
+    }
 }

--- a/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
+++ b/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
@@ -16,15 +16,37 @@ package com.norconex.commons.lang.encrypt;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Assume;
 
 public class EncryptionUtilTest {
+
+    public static final String ENVIRONMENT_KEY = "TEST_ENCRYPT_KEY";
+    public static final String PROPERTY_KEY = "test.encrypt.key";
+    public static final String CLEAR_TEXT = "please encrypt this text.";
 
     @Test
     public void testEncrypt() {
         EncryptionKey key = new EncryptionKey("this is my secret key.");
-        String text = "please encrypt this text.";
-        String encryptedText = EncryptionUtil.encrypt(text, key);
+        String encryptedText = EncryptionUtil.encrypt(CLEAR_TEXT, key);
         String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
-        Assert.assertEquals(text, decryptedText);
+        Assert.assertEquals(CLEAR_TEXT, decryptedText);
+    }
+
+    @Test
+    public void testEnvironmentEncrypt() {
+        Assume.assumeNotNull(System.getenv(ENVIRONMENT_KEY));
+        EncryptionKey key = new EncryptionKey(ENVIRONMENT_KEY, EncryptionKey.Source.ENVIRONMENT);
+        String encryptedText = EncryptionUtil.encrypt(CLEAR_TEXT, key);
+        String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
+        Assert.assertEquals(CLEAR_TEXT, decryptedText);
+    }
+
+    @Test
+    public void testPropertyEncrypt() {
+        Assume.assumeNotNull(System.getProperty(PROPERTY_KEY));
+        EncryptionKey key = new EncryptionKey(PROPERTY_KEY, EncryptionKey.Source.PROPERTY);
+        String encryptedText = EncryptionUtil.encrypt(CLEAR_TEXT, key);
+        String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
+        Assert.assertEquals(CLEAR_TEXT, decryptedText);
     }
 }

--- a/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
+++ b/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
@@ -16,37 +16,15 @@ package com.norconex.commons.lang.encrypt;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Assume;
 
 public class EncryptionUtilTest {
-
-    public static final String ENVIRONMENT_KEY = "TEST_ENCRYPT_KEY";
-    public static final String PROPERTY_KEY = "test.encrypt.key";
-    public static final String CLEAR_TEXT = "please encrypt this text.";
 
     @Test
     public void testEncrypt() {
         EncryptionKey key = new EncryptionKey("this is my secret key.");
-        String encryptedText = EncryptionUtil.encrypt(CLEAR_TEXT, key);
+        String text = "please encrypt this text.";
+        String encryptedText = EncryptionUtil.encrypt(text, key);
         String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
-        Assert.assertEquals(CLEAR_TEXT, decryptedText);
-    }
-
-    @Test
-    public void testEnvironmentEncrypt() {
-        Assume.assumeNotNull(System.getenv(ENVIRONMENT_KEY));
-        EncryptionKey key = new EncryptionKey(ENVIRONMENT_KEY, EncryptionKey.Source.ENVIRONMENT);
-        String encryptedText = EncryptionUtil.encrypt(CLEAR_TEXT, key);
-        String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
-        Assert.assertEquals(CLEAR_TEXT, decryptedText);
-    }
-
-    @Test
-    public void testPropertyEncrypt() {
-        Assume.assumeNotNull(System.getProperty(PROPERTY_KEY));
-        EncryptionKey key = new EncryptionKey(PROPERTY_KEY, EncryptionKey.Source.PROPERTY);
-        String encryptedText = EncryptionUtil.encrypt(CLEAR_TEXT, key);
-        String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
-        Assert.assertEquals(CLEAR_TEXT, decryptedText);
+        Assert.assertEquals(text, decryptedText);
     }
 }

--- a/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
+++ b/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
@@ -14,8 +14,14 @@
  */
 package com.norconex.commons.lang.encrypt;
 
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Cipher;
+
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
+
 
 public class EncryptionUtilTest {
 
@@ -44,5 +50,20 @@ public class EncryptionUtilTest {
         String encryptedText = "aeEFKa0uXMUHT4UyeFtuHjm37NQw3vEaxY03EkkD2qM=";
         String actualClearText = EncryptionUtil.decrypt(encryptedText, key);
         Assert.assertEquals(expectedClearText, actualClearText);
+    }
+
+    @Test
+    public void testAes256bitEncryptionKey() throws NoSuchAlgorithmException {
+
+        // NOTE: this test should be true on Java 8 u162+ or on Java 9, or on any Java where JCE Unlimited Strength has been applied
+        Assume.assumeTrue(Cipher.getMaxAllowedKeyLength("AES") >= 256);
+
+        // Create round-trip encryption key
+        EncryptionKey key = new EncryptionKey("This as an encryption key", 256);
+        String text = "please encrypt this text";
+        String encryptedText = EncryptionUtil.encrypt(text, key);
+        String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
+
+        Assert.assertEquals(text, decryptedText);
     }
 }

--- a/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
+++ b/norconex-commons-lang/src/test/java/com/norconex/commons/lang/encrypt/EncryptionUtilTest.java
@@ -27,4 +27,22 @@ public class EncryptionUtilTest {
         String decryptedText = EncryptionUtil.decrypt(encryptedText, key);
         Assert.assertEquals(text, decryptedText);
     }
+
+    @Test
+    public void testEncryptTwice() {
+        EncryptionKey key = new EncryptionKey("this is my secret key.");
+        String text = "please encrypt this text.";
+        String encryptedText1 = EncryptionUtil.encrypt(text, key);
+        String encryptedText2 = EncryptionUtil.encrypt(text, key);
+        Assert.assertNotEquals(encryptedText1, encryptedText2);
+    }
+
+    @Test
+    public void testDecryptLegacy() {
+        EncryptionKey key = new EncryptionKey("This is an encryption key");
+        String expectedClearText = "Please encrypt this text";
+        String encryptedText = "aeEFKa0uXMUHT4UyeFtuHjm37NQw3vEaxY03EkkD2qM=";
+        String actualClearText = EncryptionUtil.decrypt(encryptedText, key);
+        Assert.assertEquals(expectedClearText, actualClearText);
+    }
 }


### PR DESCRIPTION
- Use Hmac with SHA256 rather than plain MD5
- Use AES 128, strongest available in usual Java Cryptography Extension (JCE)
- Fallback to decryptLegacy if an exception arises in the first algorithm
- Add a convenience class `com.norconex.commons.lang.config.PasswordKeyUtil` so that we can eventually avoid writing the code to parse passwordKey and passwordKeySource, again and again, and delegate to this convenience class.  This anticipates the likelihood that someone will demand JCE Full Strength, so that they can use longer key lengths.